### PR TITLE
Add README note for Hash integrity test (Closes #6)

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,4 +50,7 @@ Test verifies:
 Expected:
 - No crash
 - TF-IDF returns zero or safe value
+## Issue #6 – Hash integrity (MD5/SHA1)
+- TODO: Add test to verify hash output matches expected for known input.
+- Expected: Correct MD5/SHA1 value, consistent results, no crash.
 


### PR DESCRIPTION
Closes #6
Added README documentation for MD5/SHA1 hash integrity test case.
